### PR TITLE
Não tornar administradores usuários não aceitos

### DIFF
--- a/src/controllers/UnitController.js
+++ b/src/controllers/UnitController.js
@@ -1,5 +1,6 @@
 import Unit from '../models/Unit.js';
 import User from '../models/User.js';
+import { ROLE } from '../schemas/role.js';
 
 class UnitController {
 
@@ -9,9 +10,9 @@ class UnitController {
         if (!units) {
             return res
               .status(401)
-              .json({ error: 'Não Existe unidades' });
+              .json({ message: 'Não Existe unidades' });
           } else {
-              return res.json(units);
+              return res.status(200).json(units);
           }
     }
 
@@ -24,7 +25,10 @@ class UnitController {
             return res.json(unit);
         } catch(error) {
             console.log(error);
-            return res.status(error).json(error);
+            return res.status(500).json({
+                error,
+                message: "Erro ao criar unidade"
+            });
         }
     }
 
@@ -36,14 +40,14 @@ class UnitController {
         if (!unit) {
             return res
               .status(404)
-              .json({ error: 'Essa unidade não existe!' });
+              .json({ message: 'Essa unidade não existe!' });
           } else {
 
             unit.set({ name });
 
               await unit.save();
 
-              return res.json(unit);
+              return res.status(200).json(unit);
           }
       }
 
@@ -58,7 +62,7 @@ class UnitController {
               .json({ error: 'Essa unidade não existe!' });
           } else {
               await unit.destroy();
-              return res.json(unit);
+              return res.status(200).json(unit);
           }
       }
 
@@ -89,27 +93,37 @@ class UnitController {
                 where:
                 {
                     cpf: cpf,
-                    idUnit: idUnit
+                    idUnit: idUnit,
+                    accepted: true
                 }
             }
         );
 
         if (!user) {
-            return res.status(401).json(
+            return res.status(404).json(
                 {
-                    error: "Usuário não existe nesta unidade"
+                    message: "Usuário aceito não existe nesta unidade"
                 }
             );
         } else {
             try {
-                user.set({idRole: 5});
+                user.set({idRole: ROLE.ADMINISTRADOR});
                 await user.save();
-                return res.status(200).json(user);
+                const userNoPassword = {
+                  cpf: user.cpf,
+                  fullName: user.fullName,
+                  email: user.email,
+                  accepted: user.accepted,
+                  idUnit: user.idUnit,
+                  idRole: user.idRole
+                };
+                return res.status(200).json(userNoPassword);
             } catch (error) {
                 console.log(error);
                 return res.status(500).json(
                     {
-                        error: "Erro ao configurar usuário como administrador"
+                        error,
+                        message: "Erro ao configurar usuário como administrador"
                     }
                 );
             }

--- a/src/tests/__tests__/test_unit_routes.js
+++ b/src/tests/__tests__/test_unit_routes.js
@@ -3,6 +3,7 @@ import 'sequelize';
 import supertest from "supertest";
 import { app, injectDB } from "../TestApp";
 import Unit from '../../models/Unit.js';
+import { ROLE } from '../../schemas/role.js';
 
 describe('unit endpoints', () => {
   beforeEach(async () => {
@@ -81,5 +82,38 @@ describe('unit endpoints', () => {
     });
     expect(updateUnitResponse.status).toBe(200);
     expect(updateUnitResponse.body).toEqual(expect.objectContaining(expectedUnit));
+  });
+
+  test('create user and accept and add it as administrator of the default unit', async () => {
+    const testUser = {
+      fullName: "Francisco Duarte Lopes",
+      cpf: "75706593256",
+      email: "francisco.dl@gmail.com",
+      password: "fdl123456",
+      idUnit: 1,
+      idRole: 1
+    };
+
+    const expectedTestUser = {
+      fullName: testUser.fullName,
+      cpf: testUser.cpf,
+      email: testUser.email,
+      accepted: true,
+      idUnit: testUser.idUnit,
+      idRole: ROLE.ADMINISTRADOR
+    };
+    const testUserResponse = await supertest(app).post("/newUser").send(testUser);
+    expect(testUserResponse.status).toBe(200);
+
+    const acceptResponse = await supertest(app).post(`/acceptRequest/${testUser.cpf}`);
+    expect(acceptResponse.status).toBe(200);
+    expect(acceptResponse.body).toEqual({ message: "Usuário aceito com sucesso" });
+
+    const setUserResponse = await supertest(app).put("/setUnitAdmin").send({
+      idUnit: testUser.idUnit,
+      cpf: testUser.cpf
+    });
+    expect(setUserResponse.status).toBe(200);
+    expect(setUserResponse.body).toEqual(expect.objectContaining(expectedTestUser));
   });
 });


### PR DESCRIPTION
## Issue #
Closes: fga-eps-mds/2022-2-CAPJu-Doc#155

## Descrição

- agora apenas usuários aceitos podem ser administradores
- padronizar mensagens
- padronizar estados http
- testar endpoint para tornar um usuário administrador
- usar constantes e não números mágicos

## Tipos de Mudanças
<!--- Mudanças realizadas no projeto -->
- [x] Bug fix (alteração ininterrupta que corrige um problema)
- [ ] Nova feature (mudança ininterrupta que adiciona funcionalidade)
- [ ] Breaking change (correção ou recurso que faria com que a funcionalidade existente não funcionasse como esperado)
- [ ] Documentação (adição ou remoção de algum artefato)

## Checklist:
<!--- Passe por todos os pontos a seguir e coloque um x em todas as caixas que se aplicam. -->
<!--- Se você não tiver certeza sobre alguma dessas opções, não hesite em perguntar. Nós estamos aqui para ajudar! -->
- [x] Meu código segue os padrões de estilo deste projeto.
- [ ] Minha alteração requer uma alteração na documentação.
- [ ] Atualizei a documentação de acordo.
