### PR TITLE
Faz eslint reconhecer métodos privados

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,7 @@
     "jest": true
   },
   "parserOptions": {
-    "ecmaVersion": 2020,
+    "ecmaVersion": 2022,
     "sourceType": "module"
   },
   "rules": {


### PR DESCRIPTION
# Faz eslint reconhecer métodos privados

## Issue #
Closes: fga-eps-mds/2022-2-CAPJu-Doc#161

## Descrição
A ferramenta de análise estática `eslint` não reconhecia métodos privados em classes, reportando-os como erros de sintaxe. O problema foi solucionado incrementando-se a versão ECMA usada para analisar o código-fonte.

## Tipos de Mudanças
<!--- Mudanças realizadas no projeto -->
- [x] Bug fix (alteração ininterrupta que corrige um problema)
- [ ] Nova feature (mudança ininterrupta que adiciona funcionalidade)
- [ ] Breaking change (correção ou recurso que faria com que a funcionalidade existente não funcionasse como esperado)
- [ ] Documentação (adição ou remoção de algum artefato)

## Checklist:
<!--- Passe por todos os pontos a seguir e coloque um x em todas as caixas que se aplicam. -->
<!--- Se você não tiver certeza sobre alguma dessas opções, não hesite em perguntar. Nós estamos aqui para ajudar! -->
- [x] Meu código segue os padrões de estilo deste projeto.
- [ ] Minha alteração requer uma alteração na documentação.
- [ ] Atualizei a documentação de acordo.
